### PR TITLE
use setup.py to build/install, use supervisord to manage in prod, use real logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+warbdage_app.egg-info
+leaderboard/build
+leaderboard/dist

--- a/leaderboard/MANIFEST.in
+++ b/leaderboard/MANIFEST.in
@@ -1,0 +1,2 @@
+graft warbadge_app/templates
+

--- a/leaderboard/bin/gunicorn_start.sh
+++ b/leaderboard/bin/gunicorn_start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+export WARBADGE_SETTINGS=/home/warbadge/warbadge_prod_config.ini 
+NAME="warbadge_app"
+DIR="/home/warbadge"
+RUN_DIR="/home/warbadge/run"
+SOCKET="${RUN_DIR}/warbadge_gunicorn.sock"
+USER="warbadge"
+GROUP="warbadge"
+NUM_WORKERS=4
+CONFIG="/home/warbadge/warbradge_prod_config.ini"
+mkdir -p ${RUN_DIR}
+echo "STARTING GUNICORN AS $(whoami)"
+
+cd ${DIR}
+source .virtualenvs/warbadge/bin/activate
+# The app should already be installed in the venv via "setup.py install"
+
+# Start gunicorn. We set logging to stdout so it can be handled by
+# supervisord.
+exec .virtualenvs/warbadge/bin/gunicorn ${NAME}  \
+--workers 4 \
+--user=${USER} \
+--group=${GROUP} \
+--bind=unix:${SOCKET} \
+--log-level=debug \
+--log-file=-

--- a/leaderboard/build.sh
+++ b/leaderboard/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-#pep8 badge/*.py
-pycodestyle $(find leaderboard -name '*.py')

--- a/leaderboard/conf/warbadge_supervisor.conf
+++ b/leaderboard/conf/warbadge_supervisor.conf
@@ -1,0 +1,9 @@
+[program:warbadge]
+# This script launches gunicron from inside a venv
+command =  /home/warbadge/leaderboard/bin/gunicorn_start.sh
+directory = /home/warbadge/
+user = warbadge 
+stdout_logfile = /home/warbadge/warbadge-gunicorn_stdout.log
+stderr_logfile = /home/warbadge/warbadge-gunicorn_stderr.log
+redirect_stderr = True
+environment = PRODUCTION=1

--- a/leaderboard/deploy.sh
+++ b/leaderboard/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# Give the user running the service sudo access for this command and this command only:
+sudo cp /home/warbadge/warbadge/leaderboard/conf/warbadge_supervisor.conf /etc/supervisor/conf.d/
+source /home/warbadge/.virtualenvs/warbadge/bin/activate
+# Install new package in the venv
+python setup.py install
+supervisorctl --serverurl=unix:///var/run/supervisor.sock restart warbadge

--- a/leaderboard/setup.py
+++ b/leaderboard/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+from pip.req import parse_requirements
+
+install_requires = ''
+with open('requirements.txt') as fp:
+        install_requires = fp.read()
+setup(
+    name='warbdage_app',
+    version='1.0',
+    long_description=__doc__,
+    packages=['warbadge_app'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=install_requires
+)

--- a/leaderboard/warbadge_app/__init__.py
+++ b/leaderboard/warbadge_app/__init__.py
@@ -1,1 +1,4 @@
-# from warbadge_app import app as application
+""" import app as application so gunicorn can
+    find it.
+"""
+from warbadge_app.app import app as application

--- a/leaderboard/warbadge_app/app.py
+++ b/leaderboard/warbadge_app/app.py
@@ -68,7 +68,7 @@ def get_handle_for_mac(mac):
     """
     # Staff handles will be displayed as STAFF in the leaderboard.
     # TODO: Put this in config?
-    staff = ['btm', 'Terry', 'effffn', 'ipl31', 'sandinak', 'robotlandman']
+    staff = ['btm', 'Terry', 'effffn', 'ipl31', 'kencaruso', 'sandinak', 'robotlandman']
     missing_handle = "--------"
     query = "SELECT * FROM handles WHERE `badge_mac`='{0}'".format(mac)
     conn = mysql.connect()
@@ -218,7 +218,7 @@ def update_handle(badge_mac):
     """ This route creates a new entry for a handle to badge mac
     mapping.
     """
-    log("update handle for %s" % badge_mac)
+    log.info("update handle for %s", badge_mac)
     request_json = request.get_json()
     insert_template = ("INSERT INTO handles (badge_mac, handle) "
                        "VALUES('{0}', '{1}')"
@@ -228,21 +228,21 @@ def update_handle(badge_mac):
     try:
         cursor.execute(insert_template)
         conn.commit()
-        log("Finished a transaction")
+        log.debug("Finished a transaction: %s", insert_template)
         return_code = 201
     except IntegrityError as exception:
         if exception[0] == 1062:
-            log("handle %s: already exists" % badge_mac)
+            log.warn("handle for %s: already exists", badge_mac)
             return_code = 409
         else:
-            log("handle %s: MySQL ERROR: %s" % exception)
-            log("MySQL ERROR: %s" % exception)
+            log.error("badge_mac %s: MySQL ERROR: %s", badge_mac, exception)
+            log.error("MySQL ERROR: %s", exception)
             return_code = 500
     else:
-        log("handle %s: added" % badge_mac)
+        log.info("handle %s: added", badge_mac)
     finally:
         conn.close()
-    payload = json.dumps({'warbadging': True}),
+    payload = json.dumps({'warbadging': True})
     content_type = {'ContentType': 'application/json'}
     return payload, return_code, content_type
 
@@ -267,7 +267,7 @@ dfc9e1340": -68, "189c5dd58a20": -69, "881dfc913080": -79, "8478acdeff20": -59},
     # the only reasonable thing we could do given the time frame.
     user_agent = request.headers.get('User-Agent')
     if "WarBadge Experimental ShmooCon 2018" not in user_agent:
-        log("Bad User-Agent: %s" % user_agent)
+        log.error("Bad User-Agent: %s", user_agent)
         abort(403)
     insert_template = (u"INSERT INTO entries "
                        "(badge_mac, ssid, bssid_mac, rssi) "
@@ -284,20 +284,20 @@ dfc9e1340": -68, "189c5dd58a20": -69, "881dfc913080": -79, "8478acdeff20": -59},
                                                 bssid_mac, rssi)
                 cursor.execute(insert)
                 conn.commit()
-                return_code = 201
     except NameError as exception:
-        log("Bad SSID: %s" % exception)
+        log.error("Bad SSID: %s", exception)
         return_code = 403
     # TODO: Find something more specific to catch.
     except Exception as exception:  # pylint: disable=W0703
-        log("Caught Exception (unicode?) for %s: %s" % (badge_mac, exception))
-        log(request.data)
+        log.error("Caught Exception (unicode?) for %s: %s", badge_mac, exception)
+        log.error(request.data)
         return_code = 500
     else:
-        log("Successful checkin for %s" % badge_mac)
+        return_code = 201
+        log.info("Successful checkin for %s", badge_mac)
     finally:
         conn.close()
-    payload = json.dumps({'warbadging': True}),
+    payload = json.dumps({'warbadging': True})
     content_type = {'ContentType': 'application/json'}
     return payload, return_code, content_type
 

--- a/leaderboard/warbadge_app/templates/alert.html
+++ b/leaderboard/warbadge_app/templates/alert.html
@@ -1,13 +1,7 @@
             <div class="alert alert-success">
-                <strong>We have winners! Please come find Ken (email: ken@ipl31.net) in Labs to claim your prizes! 
-                    <li>1st place: golden</li>
-                    <li>2nd place: jackal</li>
-                    <li>3rd place: i3602u</li>
+                <strong>Thank you for playing! Shmoocon 2018 winners: 1st - golden, 2nd - jackal, 3rd - i3602u
                 </strong>
             </div>
             <div class="alert alert-danger">
-                <p>
-                <strong><li>The contest is over but we will leave the app running and accepting submissions</li>
-                    <li>We have tons of AA batteries in Labs, come getem</li></strong>
-                </p>
+                <strong>The contest is over but we will leave the app running and accepting submissions</strong>
             </div>

--- a/leaderboard/warbadge_supervisor.conf
+++ b/leaderboard/warbadge_supervisor.conf
@@ -1,8 +1,0 @@
-[program:warbadge]
-command =  /home/warbadge/.virtualenvs/warbadge/bin/gunicorn wsgi:app -w 4 --bind unix:/tmp/warbadge_app.sock --timeout=90 -m 007 wsgi
-directory = /home/warbadge/warbadge/leaderboard/warbadge_app
-user = warbadge 
-stdout_logfile = /home/warbadge/warbadge-gunicorn_stdout.log
-stderr_logfile = /home/warbadge/warbadge-gunicorn_stderr.log
-redirect_stderr = True
-environment = PRODUCTION=1


### PR DESCRIPTION
There is now a setup.py to build a python package. This is how I am deploying on the prod server. The "python app.py" method still applies for development and testing work. 

I have switched over to using flask logging (which uses python logger) instead of using our ghetto prints.

I added the deployment configs and scripts for gunicorn/supervisord.